### PR TITLE
Change spelling of 'cridentials' to 'credentials'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requires manually executing the following method before accessing protected spac
 
 ```authDialog.authenticate(uri, /*optional*/ successCallback, /*optional*/ errorCallback,  /*optional*/ userName,  /*optional*/ password,  /*optional*/ maxAttempts)```
 
-Credentials are automatically cached by UIWebView so you do NOT need to enter them every app start. In this case ```authDialog.authenticate``` is executed w/o showing any cridentials pop-up dialog.
+Credentials are automatically cached by UIWebView so you do NOT need to enter them every app start. In this case ```authDialog.authenticate``` is executed w/o showing any credentials pop-up dialog.
 
 After authentication is you can do XmlHttpRequests or display protected space via ```window.location = 'some protected uri' ``` or using InAppBrowser plugin.
 
@@ -44,7 +44,7 @@ On Windows Tablet/PC (Windows 8.0 and Windows 8.1) native authentication dialog 
 
 On Windows Phone 8.1 authentication dialog is automatically showed for XmlHttpRequests only, InAppBrowser plugin is NOT currently supported.
 
-Plugin overrides default XmlHttpRequest via custom wrapper based on original one to automatically show cridentials dialog when it is necessary. Credentials dialog is html based and does not support hardware back button.
+Plugin overrides default XmlHttpRequest via custom wrapper based on original one to automatically show credentials dialog when it is necessary. Credentials dialog is html based and does not support hardware back button.
 
 Credentials are NOT persisted between app sessions so you need to enter them once per application start.
 

--- a/src/ios/AuthenticationDialog.h
+++ b/src/ios/AuthenticationDialog.h
@@ -26,7 +26,7 @@ typedef void (^CredentialsViewCallback)(NSString* userName, NSString* password, 
 
 @property (copy) CredentialsViewCallback onResult;
 
-- (void) requestUserCridentials: (NSString*) uri;
+- (void) requestUserCredentials: (NSString*) uri;
 
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex;
 

--- a/src/ios/AuthenticationDialog.m
+++ b/src/ios/AuthenticationDialog.m
@@ -74,9 +74,9 @@ CredentialsViewController * credentialsViewController;
 {
     NSLog(@"AuthDialog: willSendRequestForAuthenticationChallenge %@", challenge.protectionSpace);
  
-    // if no cridentials are passed during first authentication attempt then
-    // try to pass challenge automatically (using cached cridentials)
-    // this makes it possible to avoid passing cridentials every app start
+    // if no credentials are passed during first authentication attempt then
+    // try to pass challenge automatically (using cached credentials)
+    // this makes it possible to avoid passing credentials every app start
     if ([challenge previousFailureCount] == 0 && self.allowBypassAuth) {
         [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
         return;
@@ -85,14 +85,14 @@ CredentialsViewController * credentialsViewController;
     if ([challenge previousFailureCount] == 0 && [self isSupportedAuthMethod: challenge.protectionSpace.authenticationMethod])
     {
 
-        // use predefined cridentials if provided
+        // use predefined credentials if provided
         if (![self.userName isEqual:[NSNull null]] && ![self.password isEqual:[NSNull null]]) {
                 
             [[challenge sender] useCredential:[NSURLCredential credentialWithUser:self.userName
                                                                              password:self.password
                                                                       persistence:NSURLCredentialPersistencePermanent]
                        forAuthenticationChallenge:challenge];
-        } else { // request cridentials
+        } else { // request credentials
             credentialsViewController = [[CredentialsViewController alloc] init];
                 
             credentialsViewController.onResult = ^(NSString * userName, NSString* password, BOOL isCancelled)  {
@@ -109,7 +109,7 @@ CredentialsViewController * credentialsViewController;
                 }
             };
                 
-            [credentialsViewController requestUserCridentials:self.uri];
+            [credentialsViewController requestUserCredentials:self.uri];
         }
     }
     else
@@ -122,7 +122,7 @@ CredentialsViewController * credentialsViewController;
 
 @implementation CredentialsViewController {}
 
-- (void) requestUserCridentials: (NSString*) uri
+- (void) requestUserCredentials: (NSString*) uri
 {
     
     // TODO consider using UIAlertController (available starting from iOS 8.0)

--- a/src/ios/authDialog.js
+++ b/src/ios/authDialog.js
@@ -25,7 +25,7 @@ function authenticateOnce (uri, successCallback, errorCallback, userName, passwo
     cordova.exec(successCallback, errorCallback, 'AuthDialog', 'authenticate', [uri, userName, password, allowBypassAuth]);
 }
 
-authDialog.authenticate = function (uri, successCallback, /*optional*/ errorCallback,  /*optional*/ userName,  /*optional*/ password,  /*optional*/ maxAttempts) {
+authDialog.authenticate = function (uri, /*optional*/ successCallback, /*optional*/ errorCallback,  /*optional*/ userName,  /*optional*/ password,  /*optional*/ maxAttempts) {
     
     if (!uri) {
         throw new Error('Uri is not specified');
@@ -46,14 +46,14 @@ authDialog.authenticate = function (uri, successCallback, /*optional*/ errorCall
         }
         
         // if first attemp has failed then user name and password are invalid
-        // so we should ask user to provide another cridentials so we don't pass user/password
+        // so we should ask user to provide another credentials so we don't pass user/password
         setTimeout(function() {
              authenticateOnce (uri, successCallback, onError, null, null, false);
         });
     };
     
     // allowBypass specifies whether app should try to resolve authentication challenge automatically
-    // first (cached cridentials). This should be done only if no user and password are provided;
+    // first (cached credentials). This should be done only if no user and password are provided;
     // this makes it possible to avoid passing credentials every app start
     authenticateOnce (uri, successCallback, onError, userName, password, !(userName || password));
 };


### PR DESCRIPTION
Also, add /*optional*/ comment in front of successCallback to match docs.
