### PR TITLE
Add clearCredentials method for iOS

### DIFF
--- a/src/ios/AuthenticationDialog.m
+++ b/src/ios/AuthenticationDialog.m
@@ -32,6 +32,21 @@
     [NSURLConnection  connectionWithRequest:request delegate:self];
 }
 
+-(void)clearCredentials:(CDVInvokedUrlCommand*) command
+{
+    NSDictionary* credentialsDict = [[NSURLCredentialStorage sharedCredentialStorage] allCredentials];
+    
+    for (NSURLProtectionSpace* protectionSpace in credentialsDict){
+        NSDictionary* userNameDict = credentialsDict[protectionSpace];
+        for (NSString* userName in userNameDict){
+            NSURLCredential* credential = userNameDict[userName];
+            [[NSURLCredentialStorage sharedCredentialStorage] removeCredential:credential forProtectionSpace:protectionSpace];
+        }
+    }
+    
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+}
+
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
     CDVPluginResult* errorResult;
     if (error.code == NSURLErrorUserCancelledAuthentication) {

--- a/src/ios/AuthenticationDialog.m
+++ b/src/ios/AuthenticationDialog.m
@@ -44,6 +44,8 @@
         }
     }
     
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
+    
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 

--- a/src/ios/authDialog.js
+++ b/src/ios/authDialog.js
@@ -58,4 +58,8 @@ authDialog.authenticate = function (uri, successCallback, /*optional*/ errorCall
     authenticateOnce (uri, successCallback, onError, userName, password, !(userName || password));
 };
 
+authDialog.clearCredentials = function (successCallback, errorCallback) {
+    cordova.exec(successCallback, errorCallback, 'AuthDialog', 'clearCredentials', []);
+};
+
 module.exports = authDialog;


### PR DESCRIPTION
Becuase the plugin saves credentials for iOS permanently, there is no way to present the dialog again if the user wants to log in with different credentials. This function will clear out all saved credentials for the app so the next time authenticate is called, the dialog will be shown.
