### PR TITLE
Display keyboard for dialog on iOS 8

### DIFF
--- a/src/ios/AuthenticationDialog.m
+++ b/src/ios/AuthenticationDialog.m
@@ -153,4 +153,10 @@ CredentialsViewController * credentialsViewController;
     self.onResult(username.text, password.text, false);
 }
 
+- (void)didPresentAlertView:(UIAlertView *)alertView
+{
+    //show keyboard on iOS 8
+    [[alertView textFieldAtIndex:0] selectAll:nil];
+}
+
 @end


### PR DESCRIPTION
On iOS 8 the keyboard doesn't automatically appear when the authentication dialog appears. Adding this code causes the keyboard to appear when the dialog shows and gives it the same behavior as iOS 7 and Android.
